### PR TITLE
Fixing squid:S1118 -  Utility classes should not have public constructors

### DIFF
--- a/src/main/java/net/daboross/bukkitdev/skywars/config/MainConfigDefaults.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/config/MainConfigDefaults.java
@@ -34,6 +34,8 @@ public class MainConfigDefaults {
     public static final String LOCALE = Locale.getDefault().getLanguage();
 //    public static final boolean PER_ARENA_DEATH_MESSAGES_ENABLED = true;
 //    public static final boolean PER_ARENA_WIN_MESSAGES_ENABLED = false;
+    
+    private MainConfigDefaults() {}
 
     public static class Score {
 
@@ -48,6 +50,8 @@ public class MainConfigDefaults {
         public static final String SQL_DATABASE = "minecraft";
         public static final String SQL_USERNAME = "root";
         public static final String SQL_PASSWORD = "aComplexPassword";
+        
+        private Score() {}
     }
 
     public static class Economy {
@@ -56,6 +60,8 @@ public class MainConfigDefaults {
         public static final int WIN_REWARD = 10;
         public static final int KILL_REWARD = 10;
         public static final boolean MESSAGE = true;
+        
+        private Economy() {}
     }
 
     public static class CommandWhitelist {
@@ -63,6 +69,8 @@ public class MainConfigDefaults {
         public static final boolean WHITELIST_ENABLED = true;
         public static final boolean IS_BLACKLIST = false;
         public static final List<String> COMMAND_WHITELIST = Arrays.asList("/skywars", "/sw", "/me");
+        
+        private CommandWhitelist() {}
     }
 
     public static class Hooks {
@@ -70,5 +78,7 @@ public class MainConfigDefaults {
         public static final boolean MULTIVERSE_CORE = true;
         public static final boolean MULTIVERSE_INVENTORIES = true;
         public static final boolean WORLDEDIT = true;
+        
+        private Hooks() {}
     }
 }

--- a/src/main/java/net/daboross/bukkitdev/skywars/config/MainConfigKeys.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/config/MainConfigKeys.java
@@ -29,6 +29,8 @@ public class MainConfigKeys {
     public static final String LOCALE = "locale";
 //    public static final String PER_ARENA_DEATH_MESSAGES_ENABLED = "enable-per-arena-death-messages";
 //    public static final String PER_ARENA_WIN_MESSAGES_ENABLED = "enable-per-arena-win-messages";
+    
+    private MainConfigKeys() {}
 
     public static class Score {
 
@@ -43,6 +45,8 @@ public class MainConfigKeys {
         public static final String SQL_DATABASE = "points.sql.database";
         public static final String SQL_USERNAME = "points.sql.username";
         public static final String SQL_PASSWORD = "points.sql.password";
+        
+        private Score() {}
     }
 
     public static class Economy {
@@ -51,6 +55,8 @@ public class MainConfigKeys {
         public static final String WIN_REWARD = "economy.win-reward";
         public static final String KILL_REWARD = "economy.kill-reward";
         public static final String MESSAGE = "economy.reward-messages";
+        
+        private Economy() {}
     }
 
     public static class CommandWhitelist {
@@ -58,6 +64,8 @@ public class MainConfigKeys {
         public static final String WHITELIST_ENABLED = "command-whitelist.whitelist-enabled";
         public static final String IS_BLACKLIST = "command-whitelist.treated-as-blacklist";
         public static final String COMMAND_WHITELIST = "command-whitelist.whitelist";
+        
+        private CommandWhitelist() {}
     }
 
     public static class Hooks {
@@ -65,11 +73,15 @@ public class MainConfigKeys {
         public static final String MULTIVERSE_CORE = "hooks.multiverse-core-hook";
         public static final String MULTIVERSE_INVENTORIES = "hooks.multiverse-inventories-hook";
         public static final String WORLDEDIT = "hooks.worldedit-hook";
+        
+        private Hooks() {}
     }
 
     public static class Deprecated {
 
         public static final String PREFIX_CHAT = "points.should-prefix-chat";
         public static final String CHAT_PREFIX = "points.chat-prefix";
+        
+        private Deprecated() {}
     }
 }

--- a/src/main/java/net/daboross/bukkitdev/skywars/config/SkyWarsConfiguration.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/config/SkyWarsConfiguration.java
@@ -410,6 +410,8 @@ public class SkyWarsConfiguration implements SkyConfiguration {
 
         private static final String MAIN = "main-config.yml";
         private static final String ARENAS = "arenas";
+        
+        private Names() {}
     }
 
     private static class Headers {
@@ -441,5 +443,7 @@ public class SkyWarsConfiguration implements SkyConfiguration {
                 + "For documentation, please visit %n"
                 + "https://dabo.guru/projects/skywars/configuring-parent%n"
                 + "#######";
+        
+        private Headers() {}
     }
 }

--- a/src/main/java/net/daboross/bukkitdev/skywars/gist/GistReport.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/gist/GistReport.java
@@ -50,6 +50,8 @@ public class GistReport {
     private static final String GIST_API = "https://api.github.com/gists";
     private static URL GIST_API_URL;
     private static final String ISGD_API = "http://is.gd/create.php?format=simple&url=%s";
+    
+    private GistReport() {}
 
     /**
      * @param plugin plugin

--- a/src/main/java/net/daboross/bukkitdev/skywars/kits/SkyKitDecoder.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/kits/SkyKitDecoder.java
@@ -34,6 +34,7 @@ import org.bukkit.enchantments.Enchantment;
 
 public class SkyKitDecoder {
 
+	private SkyKitDecoder() {}
     public static SkyKit decodeKit(ConfigurationSection section, String name) throws SkyConfigurationException {
         SkyKitItem[] armor;
         try {

--- a/src/main/java/net/daboross/bukkitdev/skywars/util/CrossVersion.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/util/CrossVersion.java
@@ -25,7 +25,9 @@ import org.bukkit.entity.Damageable;
 
 public class CrossVersion {
 
-    public static void setHealth(Damageable d, double health) {
+	private CrossVersion() {}
+	
+	public static void setHealth(Damageable d, double health) {
         Validate.notNull(d, "Damageable cannot be null");
         try {
             d.setHealth(health);

--- a/src/main/java/net/daboross/bukkitdev/skywars/world/Statics.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/world/Statics.java
@@ -21,4 +21,6 @@ public class Statics {
     public static final String BASE_WORLD_NAME = "SkyWarsBaseWorld";
     public static final String ARENA_WORLD_NAME = "SkyWarsArenaWorld";
     public static final String ZIP_FILE_PATH = "/SkyWarsBaseWorld.zip";
+    
+    private Statics() {}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1118 -  Utility classes should not have public constructors". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1118


Please let me know if you have any questions.
Sameer Misger