### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/net/daboross/bukkitdev/skywars/game/KillMessages.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/game/KillMessages.java
@@ -33,6 +33,8 @@ public class KillMessages {
                     return SkyTrans.get(TransKey.GAME_DEATH_FORFEITED, player);
                 case OTHER:
                     return SkyTrans.get(TransKey.GAME_DEATH_KILLED_BY_ENVIRONMENT, player);
+                default:
+                    break;
             }
         } else {
             switch (reason) {
@@ -42,6 +44,8 @@ public class KillMessages {
                     return SkyTrans.get(TransKey.GAME_DEATH_FORFEITED_WHILE_ATTACKED, damager, player);
                 case OTHER:
                     return SkyTrans.get(TransKey.GAME_DEATH_KILLED_BY_PLAYER, damager, player);
+                default:
+                    break;
             }
         }
         throw new IllegalArgumentException("Unknown reason");

--- a/src/main/java/net/daboross/bukkitdev/skywars/listeners/MobSpawnDisable.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/listeners/MobSpawnDisable.java
@@ -39,7 +39,13 @@ public class MobSpawnDisable implements Listener {
                     case Statics.ARENA_WORLD_NAME:
                     case Statics.BASE_WORLD_NAME:
                         evt.setCancelled(true);
+                        break;
+                    default:
+                        break;
                 }
+                break;
+            default:
+                break;
         }
     }
 }

--- a/src/main/java/net/daboross/bukkitdev/skywars/listeners/PlayerStateListener.java
+++ b/src/main/java/net/daboross/bukkitdev/skywars/listeners/PlayerStateListener.java
@@ -51,6 +51,8 @@ public class PlayerStateListener implements Listener {
             case WAITING_FOR_RESPAWN:
                 plugin.getGameHandler().respawnPlayer(player);
                 break;
+            default:
+            	break;
         }
         plugin.getPlayers().unloadPlayer(player.getUniqueId());
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.
Sameer Misger